### PR TITLE
Adds checkpoint overview

### DIFF
--- a/docs/en/stack/data-frames/checkpoints.asciidoc
+++ b/docs/en/stack/data-frames/checkpoints.asciidoc
@@ -14,13 +14,13 @@ If your {dataframe-transform} runs only once, there is logically only one
 checkpoint. If your {dataframe-transform} runs continuously, however, it creates
 checkpoints as it ingests and transforms new source data.
 
-For example, a {cdataframe-transform}:
+To create a checkpoint, the {cdataframe-transform}:
 
 . Checks for changes to source indices.
 +
 Using a simple periodic timer, the {dataframe-transform} checks for changes to
-the source indices based on sequence IDs. This check is done based on the
-interval defined in the transform's `frequency` property.
+the source indices. This check is done based on the interval defined in the
+transform's `frequency` property.
 +
 If the source indices remain unchanged or if a checkpoint is already in progress
 then it waits for the next timer.
@@ -36,21 +36,19 @@ synchronize the source and destination indices.
 +
 --
 The {dataframe-transform} applies changes related to either new or changed
-entities to the destination index.
-//TBD: This seems to imply it doesn't handle deletions. Do we want to clarify that?
-The set of changed entities is paginated. For each page, the
-{dataframe-transform} performs a composite aggregation using a `terms` query.
-//TBD: It's not clear why the previous two sentences are noteworthy from a user point of view.
-After all the changes have been applied, the checkpoint is complete.
+entities to the destination index. The set of changed entities is paginated. For
+each page, the {dataframe-transform} performs a composite aggregation using a
+`terms` query. After all the pages of changes have been applied, the checkpoint
+is complete.
 --
 
 This checkpoint process involves both search and indexing activity on the
 cluster. We have attempted to favor control over performance while developing
 {dataframe-transforms}. We decided it was preferable for the
-{dataframe-transform} to take longer to complete quietly in the background,
-rather than to finish quickly and take precedence in resource consumption. That
-being said, the cluster still requires enough resources to support both the
-composite aggregation search and the indexing of its results. 
+{dataframe-transform} to take longer to complete, rather than to finish quickly
+and take precedence in resource consumption. That being said, the cluster still
+requires enough resources to support both the composite aggregation search and
+the indexing of its results. 
 
 TIP: If the cluster experiences unsuitable performance degradation due to the
 {dataframe-transform}, stop the transform. Consider whether you can apply a

--- a/docs/en/stack/data-frames/checkpoints.asciidoc
+++ b/docs/en/stack/data-frames/checkpoints.asciidoc
@@ -1,0 +1,60 @@
+[role="xpack"]
+[[ml-transform-checkpoints]]
+=== {dataframe-transform-cap} checkpoints
+++++
+<titleabbrev>Checkpoints</titleabbrev>
+++++
+
+beta[]
+
+Each time a {dataframe-transform} examines the source indices and creates or
+updates the destination index, it generates a _checkpoint_.
+
+If your {dataframe-transform} runs only once, there is logically only one
+checkpoint. If your {dataframe-transform} runs continuously, however, it creates
+checkpoints as it ingests and transforms new source data.
+
+For example, a {cdataframe-transform}:
+
+. Checks for changes to source indices.
++
+Using a simple periodic timer, the {dataframe-transform} checks for changes to
+the source indices based on sequence IDs. This check is done based on the
+interval defined in the transform's `frequency` property.
++
+If the source indices remain unchanged or if a checkpoint is already in progress
+then it waits for the next timer.
+
+. Identifies which entities have changed.
++
+The {dataframe-transform} searches to see which entities have changed since the
+last time it checked. The transform's `sync` configuration object identifies a
+time field in the source indices. The transform uses the values in that field to
+synchronize the source and destination indices.
+ 
+. Updates the destination index (the {dataframe}) with the changed entities.
++
+--
+The {dataframe-transform} applies changes related to either new or changed
+entities to the destination index.
+//TBD: This seems to imply it doesn't handle deletions. Do we want to clarify that?
+The set of changed entities is paginated. For each page, the
+{dataframe-transform} performs a composite aggregation using a `terms` query.
+//TBD: It's not clear why the previous two sentences are noteworthy from a user point of view.
+After all the changes have been applied, the checkpoint is complete.
+--
+
+This checkpoint process involves both search and indexing activity on the
+cluster. We have attempted to favor control over performance while developing
+{dataframe-transforms}. We decided it was preferable for the
+{dataframe-transform} to take longer to complete quietly in the background,
+rather than to finish quickly and take precedence in resource consumption. That
+being said, the cluster still requires enough resources to support both the
+composite aggregation search and the indexing of its results. 
+
+TIP: If the cluster experiences unsuitable performance degradation due to the
+{dataframe-transform}, stop the transform. Consider whether you can apply a
+source query to the {dataframe-transform} to reduce the scope of data it
+processes. Also consider whether the cluster has sufficient resources in place
+to support both the composite aggregation search and the indexing of its
+results. 

--- a/docs/en/stack/data-frames/index.asciidoc
+++ b/docs/en/stack/data-frames/index.asciidoc
@@ -75,6 +75,7 @@ to one specific method: _{dataframe-transforms}_.
 --
 
 include::overview.asciidoc[]
+include::checkpoints.asciidoc[]
 include::api-quickref.asciidoc[]
 include::dataframe-examples.asciidoc[]
 include::troubleshooting.asciidoc[]


### PR DESCRIPTION
This PR adds a topic about data frame transform checkpoints in the Stack Overview.

It builds on the structural changes in https://github.com/elastic/stack-docs/pull/435 